### PR TITLE
fix(build) split DATABASE_BACKEND parameter

### DIFF
--- a/.github/workflows/syncstorage-rs.yml
+++ b/.github/workflows/syncstorage-rs.yml
@@ -24,7 +24,8 @@ env:
   SERVICE_CHANGELOG_PATH: CHANGELOG.md
   # specific for this component
   IMAGE_TAGS: mysql
-  DATABASE_BACKEND: mysql
+  SYNCSTORAGE_DATABASE_BACKEND: mysql
+  TOKENSERVER_DATABASE_BACKEND: mysql
 
 jobs:
 
@@ -231,7 +232,8 @@ jobs:
           outputs: type=image,"name=${{ env.REPOSITORY_REGISTRY }}/${{ env.REPOSITORY_FULL_NAME }}",name-canonical=true,push=true
           context: ${{ steps.prepare-variables.outputs.code_dockerfile_path }}
           build-args: |
-            DATABASE_BACKEND=${{ env.DATABASE_BACKEND }}
+            SYNCSTORAGE_DATABASE_BACKEND=${{ env.SYNCSTORAGE_DATABASE_BACKEND }}
+            TOKENSERVER_DATABASE_BACKEND=${{ env.TOKENSERVER_DATABASE_BACKEND }}
           cache-from: type=registry,ref=${{ env.REPOSITORY_REGISTRY }}/${{ env.REPOSITORY_FULL_NAME }}:buildcache-${{ env.SERVICE_NAME }}-${{ steps.image_name.outputs.docker_image_name_suffix }}-${{ needs.prepare-env.outputs.service_tag }}-${{ steps.prepare-platform-pair.outputs.platform_pair }}
           cache-to: type=registry,ref=${{ env.REPOSITORY_REGISTRY }}/${{ env.REPOSITORY_FULL_NAME }}:buildcache-${{ env.SERVICE_NAME }}-${{ steps.image_name.outputs.docker_image_name_suffix }}-${{ needs.prepare-env.outputs.service_tag }}-${{ steps.prepare-platform-pair.outputs.platform_pair }},mode=max
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ All the images are updated weekly to the latest tag available from Mozilla's off
 - [ghcr.io/porelli/firefox-sync:syncstorage-rs-mysql-latest](https://github.com/porelli/firefox-sync/pkgs/container/firefox-sync/versions)
     - GitHub [workflow](/.github/workflows/syncstorage-rs.yml) and [logs](https://github.com/porelli/firefox-sync/actions/workflows/syncstorage-rs.yml)
     - Base image: [Mozilla's](https://github.com/mozilla-services/syncstorage-rs/blob/master/Dockerfile) container
-    - Base image differences: image built with `DATABASE_BACKEND=mysql` to use the MySQL-compatible interface instead of Google Spanner
+    - Base image differences: image built with `SYNCSTORAGE_DATABASE_BACKEND=mysql` and `TOKENSERVER_DATABASE_BACKEND=mysql` to use the MySQL-compatible interface instead of Google Spanner
     - source code: https://github.com/mozilla-services/syncstorage-rs
         - code changes: none
 - [ghcr.io/porelli/firefox-sync:syncstorage-rs-mysql-init-latest](https://github.com/porelli/firefox-sync/pkgs/container/firefox-sync/versions)


### PR DESCRIPTION
Upstream split the `DATABASE_BACKEND` parameter/var into `SYNCSTORAGE_DATABASE_BACKEND` and `TOKENSERVER_DATABASE_BACKEND` in https://github.com/mozilla-services/syncstorage-rs/pull/1840